### PR TITLE
Add new maintainers, and update Derek's e-mail address

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,6 +11,8 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
+			"adisky",
+			"dims",
 			"dmcgowan",
 		]
 
@@ -22,7 +24,17 @@
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
 
+	[people.adisky]
+	Name = "Aditi Sharma"
+	Email = "adi.sky17@gmail.com"
+	GitHub = "adisky"
+
+	[people.dims]
+	Name = "Davanum Srinivas"
+	Email = "davanum@gmail.com"
+	GitHub = "dims"
+
 	[people.dmcgowan]
 	Name = "Derek McGowan"
-	Email = "derek@docker.com"
+	Email = "derek@mcg.dev"
 	GitHub = "dmcgowan"


### PR DESCRIPTION
@dmcgowan @dims @adisky PTAL

@dmcgowan - we moved this repository to the Moby org as Docker itself was not using this dependency. Kubernetes is currently the only (or at least "main") consumer of this package, so I asked @dims to suggest maintainers (the repository had been mostly dormant for years, so I don't expect a lot of changes coming)