### PR TITLE
Switch from docker->moby for spdystream

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,6 @@
 # Spdystream maintainers file
 #
-# This file describes who runs the docker/spdystream project and how.
+# This file describes who runs the moby/spdystream project and how.
 # This is a living document - if you see something out of date or missing, speak up!
 #
 # It is structured to be consumable by both humans and programs.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docker/spdystream"
+	"github.com/moby/spdystream"
 	"net"
 	"net/http"
 )
@@ -49,7 +49,7 @@ Server example (mirroring server without auth)
 package main
 
 import (
-	"github.com/docker/spdystream"
+	"github.com/moby/spdystream"
 	"net"
 )
 

--- a/connection.go
+++ b/connection.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/spdystream/spdy"
+	"github.com/moby/spdystream/spdy"
 )
 
 var (
@@ -117,7 +117,7 @@ Loop:
 			// attempts to grab the write lock that Write() already has, causing a
 			// deadlock.
 			//
-			// See https://github.com/docker/spdystream/issues/49 for more details.
+			// See https://github.com/moby/spdystream/issues/49 for more details.
 			go func() {
 				for range resetChan {
 				}
@@ -216,7 +216,7 @@ type Connection struct {
 	shutdownChan chan error
 	hasShutdown  bool
 
-	// for testing https://github.com/docker/spdystream/pull/56
+	// for testing https://github.com/moby/spdystream/pull/56
 	dataFrameHandler func(*spdy.DataFrame) error
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/docker/spdystream
+module github.com/moby/spdystream
 
 go 1.13
 

--- a/priority.go
+++ b/priority.go
@@ -20,7 +20,7 @@ import (
 	"container/heap"
 	"sync"
 
-	"github.com/docker/spdystream/spdy"
+	"github.com/moby/spdystream/spdy"
 )
 
 type prioritizedFrame struct {

--- a/priority_test.go
+++ b/priority_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/spdystream/spdy"
+	"github.com/moby/spdystream/spdy"
 )
 
 func TestPriorityQueueOrdering(t *testing.T) {

--- a/spdy_test.go
+++ b/spdy_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/spdystream/spdy"
+	"github.com/moby/spdystream/spdy"
 )
 
 func TestSpdyStreams(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/spdystream/spdy"
+	"github.com/moby/spdystream/spdy"
 )
 
 var (

--- a/ws/ws_test.go
+++ b/ws/ws_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/spdystream"
+	"github.com/moby/spdystream"
 	"github.com/gorilla/websocket"
 )
 


### PR DESCRIPTION
Avoid the redirect and reflect the new github org this repo is in.

Once this is in, we can cut a new tag say v0.2.0 and switch kubernetes/kubernetes to use the new name.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>