### PR TITLE
gha: update go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
 
@@ -12,21 +13,20 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.13.x, 1.18.x, 1.19.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Validate headers
+      if: startsWith(matrix.go-version, '1.13') == false
       run: |
-        pushd $(mktemp -d) \
-        && go get -u github.com/kunalkushwaha/ltag \
-        && popd \
+        go install github.com/kunalkushwaha/ltag@latest \
         && ./scripts/validate/fileheader
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION

Looks like CI was no longer working, because `ltag` now required a newer version of go;

```
pushd $(mktemp -d) \
  && go get -u github.com/kunalkushwaha/ltag \
  && popd \
  && ./scripts/validate/fileheader
  shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.13.15/x64
/tmp/tmp.wrQsimdF1t ~/work/spdystream/spdystream
# github.com/kunalkushwaha/ltag
Error: /home/runner/go/src/github.com/kunalkushwaha/ltag/bash.go:25:15: undefined: os.ReadFile
Error: /home/runner/go/src/github.com/kunalkushwaha/ltag/dockerfile.go:23:15: undefined: os.ReadFile
Error: /home/runner/go/src/github.com/kunalkushwaha/ltag/golang.go:23:15: undefined: os.ReadFile
Error: /home/runner/go/src/github.com/kunalkushwaha/ltag/makefile.go:15:15: undefined: os.ReadFile
Error: Process completed with exit code 2.
```