### PR TITLE
Avoid leaking goroutines on close

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -741,7 +741,15 @@ func (s *Connection) shutdown(closeTimeout time.Duration) {
 	}
 
 	if err != nil {
-		duration := 10 * time.Minute
+		// default to 1 second
+		duration := time.Second
+		// if a closeTimeout was given, use that, clipped to 1s-10m
+		if closeTimeout > time.Second {
+			duration = closeTimeout
+		}
+		if duration > 10*time.Minute {
+			duration = 10 * time.Minute
+		}
 		timer := time.NewTimer(duration)
 		defer timer.Stop()
 		select {

--- a/connection.go
+++ b/connection.go
@@ -712,7 +712,9 @@ func (s *Connection) shutdown(closeTimeout time.Duration) {
 
 	var timeout <-chan time.Time
 	if closeTimeout > time.Duration(0) {
-		timeout = time.After(closeTimeout)
+		timer := time.NewTimer(closeTimeout)
+		defer timer.Stop()
+		timeout = timer.C
 	}
 	streamsClosed := make(chan bool)
 
@@ -806,7 +808,9 @@ func (s *Connection) CloseWait() error {
 func (s *Connection) Wait(waitTimeout time.Duration) error {
 	var timeout <-chan time.Time
 	if waitTimeout > time.Duration(0) {
-		timeout = time.After(waitTimeout)
+		timer := time.NewTimer(waitTimeout)
+		defer timer.Stop()
+		timeout = timer.C
 	}
 
 	select {


### PR DESCRIPTION
Fixes #92 

* Avoids leaking timers in shutdown and Wait if the functions exit before the timeouts expire
* Shortens the timeout for an unhandled error from 10 minutes to 1 second. It looks like the 10 minute timeout was added in https://github.com/moby/spdystream/issues/24 / https://github.com/moby/spdystream/pull/25 without a rationale... happy to adjust this PR if there are other things aspects to consider. The paths where errors _could_ be handled are:
   1. client calls CloseWait(). We know Close() is immediately followed by Wait(), a second seems entirely sufficient.
   2. client calls Close() followed by Wait(). We don't control the calls, but the expectation is that Close() is _immediately_ followed by Wait(), so a second seems entirely sufficient.
   3. client calls NotifyClose(), GOAWAYFRAME notifies lastStreamChan, client responds by calling Wait(). lastStreamChan is notified before the shutdown is begun, which gives the caller a second to call Wait() if they want to handle the shutdown error. This is the only path I don't have a great intuition of, but a second to process the channel notification seems reasonable. I also can't find a single use of this function in a [public github search](https://github.com/search?q=%2F%5C.NotifyClose%5C%28%5B%5E%29%5D%2F+language%3AGo++-path%3Atest+NOT+amqp&type=code).