### PR TITLE
gha: update actions and go versions 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: [1.13.x, 1.18.x, 1.19.x]
+        go-version: [1.13.x, 1.21.x, 1.22.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Validate headers
       if: startsWith(matrix.go-version, '1.13') == false
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code


### PR DESCRIPTION
- gha: update to actions/checkout@v4
- gha: update to actions/setup-go@v5
- gha: test against go1.13 (oldest), go1.21 and go1.22
    Keeping the oldest version in the matrix, as that's defined
    as minimum in go.mod, but testing against latest and previous.